### PR TITLE
feat: add HServerException

### DIFF
--- a/client/src/main/java/io/hstream/HServerException.java
+++ b/client/src/main/java/io/hstream/HServerException.java
@@ -1,0 +1,41 @@
+package io.hstream;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+
+public class HServerException extends RuntimeException {
+  ErrBody errBody;
+
+  static class ErrBody {
+    int error;
+    String message;
+    JsonElement extra;
+  }
+
+  HServerException(ErrBody errBody) {
+    this.errBody = errBody;
+  }
+
+  @Override
+  public String getMessage() {
+    return getErrorMessage();
+  }
+
+  public String getErrorMessage() {
+    return errBody.message;
+  }
+
+  public String getRawErrorBody() {
+    return new Gson().toJson(errBody);
+  }
+
+  public static HServerException tryToHServerException(String errBodyStr) {
+    try {
+      var errBody = new Gson().fromJson(errBodyStr, ErrBody.class);
+      return new HServerException(errBody);
+    } catch (JsonSyntaxException e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
1. add HServerException
2. avoid unnecessary blocking `future -> join` (which will wrap exceptions in a CompleteException)
3. remove unnecessary exception stack trace logs